### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.6.1 (2025-07-16)
+
+
+
+### Bug Fixes
+* thing ([`46ff848`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/46ff848d78578995c56ba5aa9169dcbb7e323631))
+* Installer now enables the Deadline addon in Blender. (#240) ([`4422a7a`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/4422a7a17952164d5ab98ead5ddcbbbe6e508f38))
+* Installer now enables the Deadline addon in Blender. ([`4422a7a`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/4422a7a17952164d5ab98ead5ddcbbbe6e508f38))
+* remove tmp installer directory after install (#235) ([`63a13d7`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/63a13d79281b658d691ca9a29eabbad2de3774f3))
+* Asset References on Network Drives are UNC Paths (#231) ([`8162022`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/81620228b00c949f0b29e348423d59e381059553))
+
 ## 0.5.4 (2025-07-02)
 
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -21,7 +21,7 @@ bl_info = {
     "name": "Deadline Cloud for Blender",
     "description": "Submit to AWS Deadline Cloud",
     "author": "AWS",
-    "version": (0, 5, 4),
+    "version": (0, 6, 1),
     "blender": (3, 6, 0),
     "category": "Render",
 }


### PR DESCRIPTION
## 0.6.1 (2025-07-16)



### Bug Fixes
* thing ([`46ff848`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/46ff848d78578995c56ba5aa9169dcbb7e323631))
* Installer now enables the Deadline addon in Blender. (#240) ([`4422a7a`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/4422a7a17952164d5ab98ead5ddcbbbe6e508f38))
* Installer now enables the Deadline addon in Blender. ([`4422a7a`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/4422a7a17952164d5ab98ead5ddcbbbe6e508f38))
* remove tmp installer directory after install (#235) ([`63a13d7`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/63a13d79281b658d691ca9a29eabbad2de3774f3))
* Asset References on Network Drives are UNC Paths (#231) ([`8162022`](https://github.com/moorec-aws/deadline-cloud-for-blender/commit/81620228b00c949f0b29e348423d59e381059553))
